### PR TITLE
Emulate possible overflow in cs-random

### DIFF
--- a/cs-random.js
+++ b/cs-random.js
@@ -43,6 +43,9 @@ function CSRandom(Seed) {
 	for (k = 1; k < 5; k++) {
 		for (i = 1; i < 56; i++) {
 			this.SeedArray[i] -= this.SeedArray[1 + (i + 30) % 55];
+			if (this.SeedArray[i] > INT_MAX) {
+				this.SeedArray[i] -= (Math.abs(INT_MIN) + INT_MAX);
+			}
 			if (this.SeedArray[i] < 0) {
 				this.SeedArray[i] += MBIG;
 			}


### PR DESCRIPTION
I found an issue when predicting the travelling cart contents. The following code:

```javascript
rng = new CSRandom(263861444);
for (slot = 1; slot <= 10; slot++) {
    // log item ID
    console.log(rng.Next(2, 790));

    // price calculation
    rng.Next(1, 11);
    rng.Next(3, 6);

    // quantity calculation
    rng.NextDouble();
}
```

threw up an item ID larger than 790 (875, in this case). (See https://mouseypounds.github.io/stardew-predictor/?id=263861388 - last week of summer)

Turns out, in the initialisation of the random class, there's a small chance that a value in SeedArray may overflow. In the C# implementation, this doesn't throw an error, and "wraps around". I've added a line to emulate this overflow.

I used dotfiddle to check the C# implementation's output against my tests: https://dotnetfiddle.net/ZCInt9