### PR TITLE
Clarify predictability of Snow days.

### DIFF
--- a/index.html
+++ b/index.html
@@ -615,7 +615,7 @@ wall/floor without buying the <a href="https://stardewvalleywiki.com/Catalogue">
 </section>
 <section id="sec-greenrain" class="tab-panel">
 <h3>Green Rain</h3>
-<p class="intro" id="greenrain-intro">Starting in Stardew 1.6, Pelican Town weather can be partially predicted. If the app shows "Rain" it could also be (unpredictably) upgraded to a Storm, and if the app shows "Sun" it could be (unpredictably) upgraded into Wind/Snow depending on season. Ginger Island weather is not predictable.</p>
+<p class="intro" id="greenrain-intro">Starting in Stardew 1.6, Pelican Town weather can be partially predicted. If the app shows "Rain" it could also be (unpredictably) upgraded to a Storm, and if the app shows "Sun" it could be (unpredictably for Wind) upgraded into Wind/Snow depending on season. Ginger Island weather is not predictable.</p>
 <p class="note" id="greenrain-note"></p>
 <fieldset id="greenrain-buttons"><div class="buttons">
 <button id="greenrain-prev-year" type="button" class="browse">&lt;&lt; Previous Year</button>


### PR DESCRIPTION
Minor wording correction.  `WinterSnow` uses the condition `SEASON winter, SYNCED_RANDOM day location_weather 0.63` and is therefor seeded.