### PR TITLE
Make output table headers sticky

### DIFF
--- a/stardew-predictor.css
+++ b/stardew-predictor.css
@@ -236,6 +236,10 @@ th {
 td {
 	color: black;
 }
+table.output thead {
+	position: sticky;
+	top: 0;
+}
 table.output th, table.output td {
 	padding: 3px 8px;
 }


### PR DESCRIPTION
This change would make some of the output table headers have sticky position--that is, remain visible at the top of the browser window when scrolling past the top of the table--which is, in my opinion, very helpful for some tables, particularly the enchants table.

| Before | After |
|:----------:|:-------:|
| ![Screenshot 2024-05-21 at 21-49-42 Stardew Predictor](https://github.com/MouseyPounds/stardew-predictor/assets/2199511/00191a29-591d-49b9-ae34-7dc2e0a42b8b) | ![Screenshot 2024-05-21 at 21-49-31 Stardew Predictor](https://github.com/MouseyPounds/stardew-predictor/assets/2199511/23442eb7-9cc1-4d54-8922-cacf1b250de1) |

Note, this PR does not impact any calendar tables (such as those for garbage can, mines, and night events) as those tables have the class "calendar" rather than "output". Perhaps they would also benefit from this treatment?